### PR TITLE
fix: add Redis email validation to SMTP server

### DIFF
--- a/crates/vortex-server/src/main.rs
+++ b/crates/vortex-server/src/main.rs
@@ -161,7 +161,6 @@ async fn store_email_in_redis(
 
     let key = format!("emails:{}", recipient);
 
-    // Parse the timestamp string back into a DateTime object to get the Unix timestamp
     let timestamp_dt = chrono::DateTime::parse_from_rfc3339(timestamp)
         .map_err(|e| {
             redis::RedisError::from((
@@ -185,7 +184,6 @@ async fn store_email_in_redis(
         ))
     })?;
 
-    // Use ZADD instead of RPUSH, with the Unix timestamp as the score
     let _: () = conn.zadd(&key, json, score).await?;
 
     Ok(())
@@ -260,13 +258,12 @@ async fn validate_vortex_email_with_redis(email: &str, state: &AppState) -> bool
         return false;
     }
 
-    // Then check if email exists in Redis
+    // Then get the Redis conn
     let key = format!("emails:{}", email);
     let mut conn = match state.redis_conn.lock().await.clone() {
         conn => conn,
     };
 
-    // Check if the key exists in Redis
     match redis::cmd("EXISTS")
         .arg(&key)
         .query_async::<_, i32>(&mut conn)

--- a/crates/vortex-server/src/main.rs
+++ b/crates/vortex-server/src/main.rs
@@ -260,13 +260,11 @@ async fn validate_vortex_email_with_redis(email: &str, state: &AppState) -> bool
 
     // Then get the Redis conn
     let key = format!("emails:{}", email);
-    let mut conn = match state.redis_conn.lock().await.clone() {
-        conn => conn,
-    };
+    let mut conn = state.redis_conn.lock().await.clone();
 
     match redis::cmd("EXISTS")
         .arg(&key)
-        .query_async::<_, i32>(&mut conn)
+        .query_async::<i32>(&mut conn)
         .await
     {
         Ok(exists) => exists > 0,

--- a/crates/vortex-smtp/src/lib.rs
+++ b/crates/vortex-smtp/src/lib.rs
@@ -1,4 +1,6 @@
 use std::fmt::Display;
+use std::future::Future;
+use std::pin::Pin;
 
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
@@ -41,10 +43,14 @@ pub struct State {
     data: Vec<u8>, // We can't use a &[u8], as that could cause a stack overflow
 }
 
-async fn process<T: Send + Fn(&str) -> bool>(
+async fn process<T, F>(
     mut socket: TcpStream,
     is_email_valid: T,
-) -> Result<State, Error> {
+) -> Result<State, Error> 
+where
+    T: Fn(&str) -> F + Send,
+    F: Future<Output = bool> + Send,
+{
     let mut buf = vec![0; consts::MAX_SIZE];
     tracing::debug!("processing connection");
 
@@ -152,7 +158,7 @@ async fn process<T: Send + Fn(&str) -> bool>(
 
                     let email = email.to_string();
                     let email = email.trim();
-                    if !is_email_valid(email) {
+                    if !is_email_valid(email).await {
                         tracing::trace!("email incoming, but recipient is invalid");
                         socket.write_all(messages::USER_UNKNOWN).await?;
                         continue;
@@ -209,11 +215,12 @@ pub struct Email {
     pub id: String,
 }
 
-pub async fn listen<A, F, G>(addr: A, validate_email: F, handle_event: G) -> Result<(), Error>
+pub async fn listen<A, F, Fut, G>(addr: A, validate_email: F, handle_event: G) -> Result<(), Error>
 where
     A: ToSocketAddrs + Display + Copy + Send,
-    F: Fn(&str) -> bool + Send + Sync + Clone + 'static, // Added Clone here
-    G: Fn(Event) + Send + Sync + Clone + 'static,        // Added Clone here
+    F: Fn(&str) -> Fut + Send + Sync + Clone + 'static,
+    Fut: Future<Output = bool> + Send + 'static,
+    G: Fn(Event) + Send + Sync + Clone + 'static,
 {
     let listener = TcpListener::bind(addr).await.map_err(Error::NetworkError)?;
 

--- a/crates/vortex-smtp/src/lib.rs
+++ b/crates/vortex-smtp/src/lib.rs
@@ -1,6 +1,5 @@
 use std::fmt::Display;
 use std::future::Future;
-use std::pin::Pin;
 
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
@@ -43,10 +42,7 @@ pub struct State {
     data: Vec<u8>, // We can't use a &[u8], as that could cause a stack overflow
 }
 
-async fn process<T, F>(
-    mut socket: TcpStream,
-    is_email_valid: T,
-) -> Result<State, Error> 
+async fn process<T, F>(mut socket: TcpStream, is_email_valid: T) -> Result<State, Error>
 where
     T: Fn(&str) -> F + Send,
     F: Future<Output = bool> + Send,


### PR DESCRIPTION
Fixes #27

Implements Redis email validation during SMTP RCPT TO processing to prevent auto-flagging of Vortex domains.

## Changes
- Modified SMTP library to support async validation functions
- Added non-blocking Redis existence check during email validation
- Only allows emails that exist in Redis to receive mail
- Returns "550 User unknown" for non-existent emails

## Testing
The implementation maintains existing domain validation while adding Redis checks. SMTP clients will now receive proper error responses for non-existent email addresses.
