### PR TITLE
Switch to non-interactive Turnstile

### DIFF
--- a/crates/vortex-server/src/main.rs
+++ b/crates/vortex-server/src/main.rs
@@ -2,8 +2,12 @@ use std::env;
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, Query, State},
-    http::{HeaderValue, Method, StatusCode},
+    extract::{Path, Query, Request, State},
+    http::{
+        header::{COOKIE, SET_COOKIE},
+        HeaderValue, Method, StatusCode,
+    },
+    response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
 };
@@ -46,6 +50,37 @@ struct ApiTokenQuery {
     api_token: Option<String>,
 }
 
+fn extract_api_token_from_request<T>(req: &axum::http::Request<T>) -> Option<String> {
+    // Try to get api_token from cookies first
+    if let Some(cookie_header) = req.headers().get(COOKIE) {
+        if let Ok(cookie_str) = cookie_header.to_str() {
+            for cookie in cookie_str.split(';') {
+                let cookie = cookie.trim();
+                if let Some(value) = cookie.strip_prefix("api_token=") {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+
+    // Try to get api_token from query parameters (backward compatibility)
+    if let Some(query) = req.uri().query() {
+        for pair in query.split('&') {
+            if let Some((key, value)) = pair.split_once('=') {
+                if key == "api_token" {
+                    return Some(
+                        urlencoding::decode(value)
+                            .unwrap_or_else(|_| value.into())
+                            .to_string(),
+                    );
+                }
+            }
+        }
+    }
+
+    None
+}
+
 #[derive(Clone)]
 struct AppState {
     redis_conn: Arc<Mutex<MultiplexedConnection>>,
@@ -63,7 +98,19 @@ impl KeyExtractor for ApiTokenKeyExtractor {
         &self,
         req: &axum::http::Request<T>,
     ) -> Result<Self::Key, tower_governor::GovernorError> {
-        // Try to get api_token from query parameters
+        // Try to get api_token from cookies first
+        if let Some(cookie_header) = req.headers().get(COOKIE) {
+            if let Ok(cookie_str) = cookie_header.to_str() {
+                for cookie in cookie_str.split(';') {
+                    let cookie = cookie.trim();
+                    if let Some(value) = cookie.strip_prefix("api_token=") {
+                        return Ok(value.to_string());
+                    }
+                }
+            }
+        }
+
+        // Try to get api_token from query parameters (backward compatibility)
         if let Some(query) = req.uri().query() {
             for pair in query.split('&') {
                 if let Some((key, value)) = pair.split_once('=') {
@@ -301,6 +348,7 @@ async fn get_emails(
     State(state): State<AppState>,
     Path(email): Path<String>,
     Query(query): Query<ApiTokenQuery>,
+    request: Request,
 ) -> Result<(StatusCode, Json<Vec<ExtendedEmail>>), StatusCode> {
     if !validate_vortex_email(&email, &state.allowed_domains) {
         tracing::warn!(email, "Invalid domain in GET request");
@@ -335,7 +383,9 @@ async fn get_emails(
     // don't really have an incentive to wrap this API for spam/custom clients, since they
     // can't view the emails without a valid API token anyway.
     if state.turnstile_secret.is_some() {
-        match query.api_token {
+        let api_token = extract_api_token_from_request(&request).or(query.api_token);
+
+        match api_token {
             Some(token) => {
                 if !validate_api_token(&state, &token).await {
                     tracing::warn!("Invalid or expired API token");
@@ -357,6 +407,7 @@ async fn clear_emails(
     State(state): State<AppState>,
     Path(email): Path<String>,
     Query(query): Query<ApiTokenQuery>,
+    request: Request,
 ) -> Result<StatusCode, StatusCode> {
     if !validate_vortex_email(&email, &state.allowed_domains) {
         tracing::warn!(email, "Invalid domain requested for clearing");
@@ -365,7 +416,9 @@ async fn clear_emails(
 
     // Check API token if Turnstile is enabled
     if state.turnstile_secret.is_some() {
-        match query.api_token {
+        let api_token = extract_api_token_from_request(&request).or(query.api_token);
+
+        match api_token {
             Some(token) => {
                 if !validate_api_token(&state, &token).await {
                     tracing::warn!("Invalid or expired API token");
@@ -423,7 +476,7 @@ async fn validate_vortex_email_with_redis(email: &str, state: &AppState) -> bool
 async fn verify_turnstile(
     State(state): State<AppState>,
     Json(request): Json<TurnstileVerifyRequest>,
-) -> Result<Json<TurnstileVerifyResponse>, StatusCode> {
+) -> Result<Response, StatusCode> {
     let turnstile_secret = match &state.turnstile_secret {
         Some(secret) => secret,
         None => {
@@ -468,7 +521,19 @@ async fn verify_turnstile(
         })?;
 
     tracing::info!("API token generated and stored");
-    Ok(Json(TurnstileVerifyResponse { api_token }))
+
+    // Set cookie with the API token
+    let cookie_value = format!(
+        "api_token={}; Path=/; HttpOnly; SameSite=Strict; Max-Age={}",
+        api_token, ttl_seconds
+    );
+
+    Ok((
+        StatusCode::OK,
+        [(SET_COOKIE, cookie_value)],
+        Json(TurnstileVerifyResponse { api_token }),
+    )
+        .into_response())
 }
 
 async fn validate_api_token(state: &AppState, token: &str) -> bool {

--- a/frontend/app/components/home/turnstile-manager.tsx
+++ b/frontend/app/components/home/turnstile-manager.tsx
@@ -26,7 +26,7 @@ export default function TurnstileManager({
 			"apiToken:",
 			!!apiToken,
 		);
-	}, [siteKey, apiToken]);
+	}, [apiToken]);
 
 	useEffect(() => {
 		const interval = setInterval(() => {
@@ -49,17 +49,16 @@ export default function TurnstileManager({
 						headers: {
 							"Content-Type": "application/json",
 						},
+						credentials: "include",
 						body: JSON.stringify({ token }),
 					},
 				);
 
 				if (response.ok) {
-					const data = await response.json();
-					console.log(
-						"TurnstileManager: Verification successful, got API token",
-					);
-					setApiToken(data.api_token);
-					onTokenGenerated(data.api_token);
+					await response.json();
+					console.log("TurnstileManager: Verification successful, cookie set");
+					setApiToken("verified");
+					onTokenGenerated("verified");
 					setTurnstileError(null);
 					console.timeEnd("turnstile");
 				} else {
@@ -120,22 +119,31 @@ export default function TurnstileManager({
 		);
 	}
 
+	if (apiToken) {
+		return <NoEmailsFound dots={dots} />;
+	}
+
 	return (
-		<>
-			{siteKey && !apiToken && (
-				<Turnstile
-					siteKey={siteKey}
-					onSuccess={handleTurnstileSuccess}
-					onError={handleTurnstileError}
-					onExpire={handleTurnstileExpire}
-					options={{
-						theme: "auto",
-						size: "invisible",
-					}}
-				/>
-			)}
-			<NoEmailsFound dots={dots} />
-		</>
+		<div className="flex flex-col justify-center items-center gap-4 border border-surface0 bg-surface0/30 px-4 py-6 rounded w-full md:w-1/2 mx-auto">
+			<div className="flex flex-col items-center gap-2 w-full">
+				<h2 className="text-xl font-medium text-center">
+					Verifying your session
+				</h2>
+				<p className="text-base text-text/80 text-center">
+					This helps prevent abuse. Please wait a couple seconds{dots}
+				</p>
+			</div>
+			<Turnstile
+				siteKey={siteKey}
+				onSuccess={handleTurnstileSuccess}
+				onError={handleTurnstileError}
+				onExpire={handleTurnstileExpire}
+				options={{
+					theme: "dark",
+					size: "normal",
+				}}
+			/>
+		</div>
 	);
 }
 

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -59,13 +59,7 @@ export default function Home() {
 		queryKey: ["emails", email, apiToken],
 		queryFn: () => {
 			const siteKey = import.meta.env.VITE_TURNSTILE_SITEKEY;
-			const url = new URL(
-				`${import.meta.env.VITE_API_ENDPOINT}/emails/${email}`,
-			);
-
-			if (siteKey && apiToken) {
-				url.searchParams.append("api_token", apiToken);
-			}
+			const url = `${import.meta.env.VITE_API_ENDPOINT}/emails/${email}`;
 
 			console.log(
 				"Fetching emails for:",
@@ -76,7 +70,9 @@ export default function Home() {
 				!!apiToken,
 			);
 
-			return fetch(url.toString())
+			return fetch(url, {
+				credentials: "include",
+			})
 				.then((res) => {
 					if (!res.ok) {
 						setFirstCall(false);
@@ -160,7 +156,7 @@ export default function Home() {
 							))}
 						</Accordion.Root>
 						{/* Ensure email is not null before passing to ClearAllEmails */}
-						{email && <ClearAllEmails email={email} apiToken={apiToken} />}
+						{email && <ClearAllEmails email={email} />}
 					</div>
 				) : (
 					<TurnstileManager onTokenGenerated={setApiToken} />
@@ -170,10 +166,7 @@ export default function Home() {
 	);
 }
 
-function ClearAllEmails({
-	email,
-	apiToken,
-}: { email: string; apiToken: string | null }) {
+function ClearAllEmails({ email }: { email: string }) {
 	// email prop is guaranteed non-null here by parent logic
 	const queryClient = useQueryClient();
 
@@ -183,17 +176,11 @@ function ClearAllEmails({
 				type="button"
 				className="text-center border border-surface0 rounded hover:bg-red-500 hover:text-base px-4 py-2 w-full transition duration-350 font-semibold"
 				onClick={async () => {
-					const siteKey = import.meta.env.VITE_TURNSTILE_SITEKEY;
-					const url = new URL(
-						`${import.meta.env.VITE_API_ENDPOINT}/emails/${email}/clear`,
-					);
+					const url = `${import.meta.env.VITE_API_ENDPOINT}/emails/${email}/clear`;
 
-					if (siteKey && apiToken) {
-						url.searchParams.append("api_token", apiToken);
-					}
-
-					await fetch(url.toString(), {
+					await fetch(url, {
 						method: "DELETE",
+						credentials: "include",
 					});
 					queryClient.setQueryData(["emails", email], []);
 				}}


### PR DESCRIPTION
Implements #34 - Switch to non-interactive Turnstile

## Summary
- Replaced invisible Turnstile with non-interactive widget in dark mode
- Added styled box matching NoEmailsFound component design
- Switched from API tokens in query params to HttpOnly cookies
- Maintained backward compatibility with existing token authentication

## Test plan
- [ ] Verify Turnstile widget displays in dark mode with explanatory text
- [ ] Test cookie-based authentication flow works correctly
- [ ] Ensure backward compatibility with existing query parameter auth
- [ ] Confirm styling matches NoEmailsFound component
- [ ] Test success state transition to email view
