### PR TITLE
Correct site.webmanifest

### DIFF
--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,6 +1,5 @@
 {
-	"name": "MyWebSite",
-	"short_name": "MySite",
+	"name": "Vortex",
 	"icons": [
 		{
 			"src": "/web-app-manifest-192x192.png",
@@ -15,7 +14,7 @@
 			"purpose": "maskable"
 		}
 	],
-	"theme_color": "181825",
-	"background_color": "181825",
+	"theme_color": "#181825",
+	"background_color": "#181825",
 	"display": "standalone"
 }


### PR DESCRIPTION
The colors need a `#` to be valid, and I assume you don't want your PWA to be called MyWebSite (idk what you want for the optional Chrome-only description)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated site.webmanifest to use the correct app name and fixed color values by adding missing # for valid hex codes.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application name in the web manifest to "Vortex."
  * Improved color formatting for theme and background in the manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->